### PR TITLE
Add optional group/ldap-ou check

### DIFF
--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -15,7 +15,7 @@ type LDAPTokenIssuer struct {
 	LDAPServer        string
 	LDAPAuthenticator ldap.Authenticator
 	TokenSigner       token.Signer
-	RequiredGroup     string
+	LDAPOU            string
 }
 
 func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
@@ -27,7 +27,7 @@ func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 
 	// Authenticate the user via LDAP
-	ldapEntry, err := lti.LDAPAuthenticator.Authenticate(user, password, lti.RequiredGroup)
+	ldapEntry, err := lti.LDAPAuthenticator.Authenticate(user, password, lti.LDAPOU)
 	if err != nil {
 		glog.Errorf("Error authenticating user: %v", err)
 		resp.WriteHeader(http.StatusUnauthorized)

--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -15,6 +15,7 @@ type LDAPTokenIssuer struct {
 	LDAPServer        string
 	LDAPAuthenticator ldap.Authenticator
 	TokenSigner       token.Signer
+	RequiredGroup     string
 }
 
 func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
@@ -26,7 +27,7 @@ func (lti *LDAPTokenIssuer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 
 	// Authenticate the user via LDAP
-	ldapEntry, err := lti.LDAPAuthenticator.Authenticate(user, password)
+	ldapEntry, err := lti.LDAPAuthenticator.Authenticate(user, password, lti.RequiredGroup)
 	if err != nil {
 		glog.Errorf("Error authenticating user: %v", err)
 		resp.WriteHeader(http.StatusUnauthorized)

--- a/auth/token_issuer_test.go
+++ b/auth/token_issuer_test.go
@@ -16,7 +16,7 @@ type dummyLDAP struct {
 	err   error
 }
 
-func (d dummyLDAP) Authenticate(username, password, group string) (*ldap.Entry, error) {
+func (d dummyLDAP) Authenticate(username, password, ldapOU string) (*ldap.Entry, error) {
 	return d.entry, d.err
 }
 

--- a/auth/token_issuer_test.go
+++ b/auth/token_issuer_test.go
@@ -16,7 +16,7 @@ type dummyLDAP struct {
 	err   error
 }
 
-func (d dummyLDAP) Authenticate(username, password string) (*ldap.Entry, error) {
+func (d dummyLDAP) Authenticate(username, password, group string) (*ldap.Entry, error) {
 	return d.entry, d.err
 }
 

--- a/auth/webhook_test.go
+++ b/auth/webhook_test.go
@@ -54,7 +54,7 @@ func TestWebhook(t *testing.T) {
 
 	for i, c := range cases {
 		v := &dummyVerifier{token: c.verifiedToken, err: c.verifyErr}
-		tw := NewTokenWebhook(v)
+		tw := NewTokenWebhook(v, "")
 
 		trr := &TokenReviewRequest{
 			Spec: TokenReviewSpec{

--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -24,7 +24,7 @@ var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
 var flLdapHost = flag.String("ldap-host", "", "Host or IP of the LDAP server")
 var flLdapPort = flag.Uint("ldap-port", 389, "LDAP server port")
 var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'dc=example,dc=com'")
-var flGroup = flag.String("ldap-group", "", "Group a user must be member of")
+var flLdapOU = flag.String("ldap-ou", "", "LDAP group/organizational unit (ou) a user must be member of")
 var flUserLoginAttribute = flag.String("ldap-user-attribute", "uid", "LDAP Username attribute for login")
 var flSearchUserDN = flag.String("ldap-search-user-dn", "", "Search user DN for this app to find users (e.g.: cn=admin,dc=example,dc=com).")
 var flSearchUserPassword = flag.String("ldap-search-user-password", "", "Search user password")
@@ -88,12 +88,12 @@ func main() {
 
 	server := &http.Server{Addr: fmt.Sprintf(":%d", *flServerPort)}
 
-	webhook := auth.NewTokenWebhook(tokenVerifier)
+	webhook := auth.NewTokenWebhook(tokenVerifier, *flLdapOU)
 
 	ldapTokenIssuer := &auth.LDAPTokenIssuer{
 		LDAPAuthenticator: ldapClient,
 		TokenSigner:       tokenSigner,
-		RequiredGroup:     *flGroup,
+		LDAPOU:            *flLdapOU,
 	}
 
 	// Endpoint for authenticating with token

--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -24,6 +24,7 @@ var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
 var flLdapHost = flag.String("ldap-host", "", "Host or IP of the LDAP server")
 var flLdapPort = flag.Uint("ldap-port", 389, "LDAP server port")
 var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'dc=example,dc=com'")
+var flGroup = flag.String("ldap-group", "", "Group a user must be member of")
 var flUserLoginAttribute = flag.String("ldap-user-attribute", "uid", "LDAP Username attribute for login")
 var flSearchUserDN = flag.String("ldap-search-user-dn", "", "Search user DN for this app to find users (e.g.: cn=admin,dc=example,dc=com).")
 var flSearchUserPassword = flag.String("ldap-search-user-password", "", "Search user password")
@@ -92,6 +93,7 @@ func main() {
 	ldapTokenIssuer := &auth.LDAPTokenIssuer{
 		LDAPAuthenticator: ldapClient,
 		TokenSigner:       tokenSigner,
+		RequiredGroup:     *flGroup,
 	}
 
 	// Endpoint for authenticating with token

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -4,13 +4,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-ldap/ldap"
 )
 
 // Authenticator authenticates a user against an LDAP directory
 type Authenticator interface {
-	Authenticate(username, password string) (*ldap.Entry, error)
+	Authenticate(username, password, group string) (*ldap.Entry, error)
 }
 
 // Client represents a connection, and associated lookup strategy,
@@ -28,7 +29,7 @@ type Client struct {
 
 // Authenticate a user against the LDAP directory. Returns an LDAP entry if password
 // is valid, otherwise returns an error.
-func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
+func (c *Client) Authenticate(username, password, group string) (*ldap.Entry, error) {
 	conn, err := c.dial()
 	if err != nil {
 		return nil, fmt.Errorf("Error opening LDAP connection: %v", err)
@@ -58,6 +59,13 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 		return nil, fmt.Errorf("No result for the search filter '%s'", req.Filter)
 	case len(res.Entries) > 1:
 		return nil, fmt.Errorf("Multiple entries found for the search filter '%s': %+v", req.Filter, res.Entries)
+	}
+
+	if group != "" {
+		err = c.isInGroup(conn, username, group)
+		if err != nil {
+			return nil, fmt.Errorf("Group check failed: %s", err)
+		}
 	}
 
 	// Now that we know the user exists within the BaseDN scope
@@ -104,4 +112,27 @@ func (c *Client) newUserSearchRequest(username string) *ldap.SearchRequest {
 		TypesOnly:    false,
 		Filter:       userFilter,
 	}
+}
+
+func (c *Client) isInGroup(conn *ldap.Conn, username, group string) error {
+	req := &ldap.SearchRequest{
+		BaseDN: c.BaseDN,
+		Scope:  ldap.ScopeWholeSubtree,
+		Filter: fmt.Sprintf("(memberUid=%s)", username),
+	}
+
+	res, err := conn.Search(req)
+	if err != nil {
+		return fmt.Errorf("Error searching for user %s: %v", username, err)
+	}
+	if len(res.Entries) == 0 {
+		return fmt.Errorf("Received an empty response")
+	}
+	for _, entry := range res.Entries {
+		if strings.Contains(entry.DN, "cn="+group) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%q is not a member of %q", username, group)
 }


### PR DESCRIPTION
This PR adds an optional command line flag `--ldap-ou` which when specified checks if a user is member of the given group—or in LDAP terms organizational unit (ou).
Authorization fails if a group was specified and the user is not a member.
If no flag was given then the check is ignored.