### PR TITLE
return groups with authenticate end point and change variable name to disable tls

### DIFF
--- a/auth/webhook.go
+++ b/auth/webhook.go
@@ -50,6 +50,7 @@ func (tw *TokenWebhook) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		Authenticated: true,
 		User: UserInfo{
 			Username: token.Username,
+			Groups: token.Groups,
 		},
 	}
 

--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -20,7 +20,7 @@ const (
 	usage = "kubernetes-ldap <options>"
 )
 
-var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
+var flLdapUseInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
 var flLdapHost = flag.String("ldap-host", "", "Host or IP of the LDAP server")
 var flLdapPort = flag.Uint("ldap-port", 389, "LDAP server port")
 var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'dc=example,dc=com'")
@@ -78,7 +78,7 @@ func main() {
 		BaseDN:             *flBaseDN,
 		LdapServer:         *flLdapHost,
 		LdapPort:           *flLdapPort,
-		AllowInsecure:      *flLdapAllowInsecure,
+		UseInsecure:        *flLdapUseInsecure,
 		UserLoginAttribute: *flUserLoginAttribute,
 		SearchUserDN:       *flSearchUserDN,
 		SearchUserPassword: *flSearchUserPassword,

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -59,7 +59,7 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 	case len(res.Entries) > 1:
 		return nil, fmt.Errorf("Multiple entries found for the search filter '%s': %+v", req.Filter, res.Entries)
 	}
-
+	
 	// Now that we know the user exists within the BaseDN scope
 	// let's do user bind to check credentials using the full DN instead of
 	// the attribute used for search
@@ -78,13 +78,13 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 func (c *Client) dial() (*ldap.Conn, error) {
 	address := fmt.Sprintf("%s:%d", c.LdapServer, c.LdapPort)
 
-	if c.TLSConfig != nil {
+	if c.TLSConfig != nil && !c.AllowInsecure {
 		return ldap.DialTLS("tcp", address, c.TLSConfig)
 	}
 
 	// This will send passwords in clear text (LDAP doesn't obfuscate password in any way),
 	// thus we use a flag to enable this mode
-	if c.TLSConfig == nil && c.AllowInsecure {
+	if c.AllowInsecure {
 		return ldap.Dial("tcp", address)
 	}
 

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -19,7 +19,7 @@ type Client struct {
 	BaseDN             string
 	LdapServer         string
 	LdapPort           uint
-	AllowInsecure      bool
+	UseInsecure        bool
 	UserLoginAttribute string
 	SearchUserDN       string
 	SearchUserPassword string
@@ -41,6 +41,7 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 	} else {
 		err = conn.Bind(username, password)
 	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Error binding user to LDAP server: %v", err)
 	}
@@ -78,13 +79,15 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 func (c *Client) dial() (*ldap.Conn, error) {
 	address := fmt.Sprintf("%s:%d", c.LdapServer, c.LdapPort)
 
-	if c.TLSConfig != nil && !c.AllowInsecure {
+	if c.TLSConfig != nil && !c.UseInsecure {
+		fmt.Println("inside secure")
 		return ldap.DialTLS("tcp", address, c.TLSConfig)
 	}
 
 	// This will send passwords in clear text (LDAP doesn't obfuscate password in any way),
 	// thus we use a flag to enable this mode
-	if c.AllowInsecure {
+	if c.UseInsecure {
+		fmt.Println("inside insecure")
 		return ldap.Dial("tcp", address)
 	}
 

--- a/ldap/client.go
+++ b/ldap/client.go
@@ -80,14 +80,12 @@ func (c *Client) dial() (*ldap.Conn, error) {
 	address := fmt.Sprintf("%s:%d", c.LdapServer, c.LdapPort)
 
 	if c.TLSConfig != nil && !c.UseInsecure {
-		fmt.Println("inside secure")
 		return ldap.DialTLS("tcp", address, c.TLSConfig)
 	}
 
 	// This will send passwords in clear text (LDAP doesn't obfuscate password in any way),
 	// thus we use a flag to enable this mode
 	if c.UseInsecure {
-		fmt.Println("inside insecure")
 		return ldap.Dial("tcp", address)
 	}
 

--- a/token/token.go
+++ b/token/token.go
@@ -22,6 +22,7 @@ var curveEll = elliptic.P256()
 // AuthToken contains information about the authenticated user
 type AuthToken struct {
 	Username   string
+	Groups []string
 	Assertions map[string]string
 }
 


### PR DESCRIPTION
The pull request address two things:

1. It changes the variable name for disable-tls to 'UseInsecure' instead of 'AllowInsecure' and fix the if condition to allow this
2. it returns the list of groups the user is part of from 'membersOf' attribute

Please let me know if this looks ok or more changes are needed.

Thanks
Rajat Jindal