### PR TITLE
return groups and allow insecure ldap

### DIFF
--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -8,6 +8,7 @@ import (
 	goldap "github.com/go-ldap/ldap"
 	"github.com/golang/glog"
 	"strings"
+	"regexp"
 )
 
 // LDAPTokenIssuer issues cryptographically secure tokens after authenticating the
@@ -53,11 +54,13 @@ func (lti *LDAPTokenIssuer) getGroupsFromMembersOf(membersOf []string) []string 
 	groupsOf := []string {}
 	uniqueGroups := make(map[string]struct{})
 
+	re := regexp.MustCompile(`(?i)CN=`)
+
 	for _, memberOf := range membersOf {
 		splitted_str := strings.Split(memberOf, ",")
 		for _, element := range splitted_str {
-			if strings.Contains(element, "CN=") {
-				group := strings.Replace(element, "CN=", "", -1)
+			if strings.Contains(strings.ToUpper(element), "CN=") {
+				group := re.ReplaceAllString(element, "")
 
 				if _, ok := uniqueGroups[group]; !ok {
 					groupsOf = append(groupsOf, group)

--- a/auth/token_issuer.go
+++ b/auth/token_issuer.go
@@ -59,14 +59,19 @@ func (lti *LDAPTokenIssuer) getGroupsFromMembersOf(membersOf []string) []string 
 	for _, memberOf := range membersOf {
 		splitted_str := strings.Split(memberOf, ",")
 		for _, element := range splitted_str {
-			if strings.Contains(strings.ToUpper(element), "CN=") {
-				group := re.ReplaceAllString(element, "")
-
-				if _, ok := uniqueGroups[group]; !ok {
-					groupsOf = append(groupsOf, group)
-					uniqueGroups[group] = struct{}{}
-				}
+			if !strings.Contains(strings.ToUpper(element), "CN=") {
+				continue
 			}
+
+			group := re.ReplaceAllString(element, "")
+
+			if _, ok := uniqueGroups[group]; ok {
+				//this group has been considered and added already
+				continue
+			}
+
+			groupsOf = append(groupsOf, group)
+			uniqueGroups[group] = struct{}{}
 		}
 	}
 

--- a/auth/webhook.go
+++ b/auth/webhook.go
@@ -50,6 +50,7 @@ func (tw *TokenWebhook) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		Authenticated: true,
 		User: UserInfo{
 			Username: token.Username,
+			Groups: token.Groups,
 		},
 	}
 

--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -20,7 +20,7 @@ const (
 	usage = "kubernetes-ldap <options>"
 )
 
-var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
+var flLdapUseInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
 var flLdapHost = flag.String("ldap-host", "", "Host or IP of the LDAP server")
 var flLdapPort = flag.Uint("ldap-port", 389, "LDAP server port")
 var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'dc=example,dc=com'")
@@ -78,7 +78,7 @@ func main() {
 		BaseDN:             *flBaseDN,
 		LdapServer:         *flLdapHost,
 		LdapPort:           *flLdapPort,
-		AllowInsecure:      *flLdapAllowInsecure,
+		UseInsecure:        *flLdapUseInsecure,
 		UserLoginAttribute: *flUserLoginAttribute,
 		SearchUserDN:       *flSearchUserDN,
 		SearchUserPassword: *flSearchUserPassword,

--- a/token/token.go
+++ b/token/token.go
@@ -22,6 +22,7 @@ var curveEll = elliptic.P256()
 // AuthToken contains information about the authenticated user
 type AuthToken struct {
 	Username   string
+	Groups []string
 	Assertions map[string]string
 }
 


### PR DESCRIPTION
Please ignore pull request #9 

This pull request address two things:

- It changes the variable name for disable-tls to 'UseInsecure' instead of 'AllowInsecure' and fix the if condition to allow this
- it returns the list of groups the user is part of from 'membersOf' attribute

Please let me know if this looks ok or more changes are needed.

Thanks
Rajat Jindal