### PR TITLE
Add StartTLS functionality

### DIFF
--- a/cmd/kubernetes-ldap.go
+++ b/cmd/kubernetes-ldap.go
@@ -20,7 +20,8 @@ const (
 	usage = "kubernetes-ldap <options>"
 )
 
-var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAP TLS")
+var flLdapAllowInsecure = flag.Bool("ldap-insecure", false, "Disable LDAPS / StartTLS")
+var flLdapStartTLS = flag.Bool("ldap-starttls", false, "Use StartTLS instead of LDAPS for encrypting the connection")
 var flLdapHost = flag.String("ldap-host", "", "Host or IP of the LDAP server")
 var flLdapPort = flag.Uint("ldap-port", 389, "LDAP server port")
 var flBaseDN = flag.String("ldap-base-dn", "", "LDAP user base DN in the form 'dc=example,dc=com'")
@@ -79,6 +80,7 @@ func main() {
 		LdapServer:         *flLdapHost,
 		LdapPort:           *flLdapPort,
 		AllowInsecure:      *flLdapAllowInsecure,
+		StartTLS:           *flLdapStartTLS,
 		UserLoginAttribute: *flUserLoginAttribute,
 		SearchUserDN:       *flSearchUserDN,
 		SearchUserPassword: *flSearchUserPassword,


### PR DESCRIPTION
Apart from having an encrypted connection from the start (LDAPS),
LDAP also supports using StartTLS: Begin with an unencrypted
connection, then update to TLS (see RFC4511 Section 4.14).

The go-ldap package already supports this. This commit makes the
functionality available to kubernetes-ldap by introducing an
additional CLI flag "ldap-starttls".

Signed-off-by: Daniel Mohr <daniel.mohr@supercrunch.io>