### PR TITLE
Fix skip insecure SSL connection issue

### DIFF
--- a/ldap/client.go
+++ b/ldap/client.go
@@ -78,13 +78,13 @@ func (c *Client) Authenticate(username, password string) (*ldap.Entry, error) {
 func (c *Client) dial() (*ldap.Conn, error) {
 	address := fmt.Sprintf("%s:%d", c.LdapServer, c.LdapPort)
 
-	if c.TLSConfig != nil {
+	if !c.TLSConfig.InsecureSkipVerify {
 		return ldap.DialTLS("tcp", address, c.TLSConfig)
 	}
 
 	// This will send passwords in clear text (LDAP doesn't obfuscate password in any way),
 	// thus we use a flag to enable this mode
-	if c.TLSConfig == nil && c.AllowInsecure {
+	if c.TLSConfig.InsecureSkipVerify && c.AllowInsecure {
 		return ldap.Dial("tcp", address)
 	}
 


### PR DESCRIPTION
When we enable the options of `--ldap-insecure` and `--ldap-skip-tls-verification`, we need to call the `ldap.dial () `function to skip the TLS authentication process. But no matter what options we add, the c.TLSConfig is never nil. So the variable we judge should be changed to `c.TLSConfig.InsecureSkipVerify`